### PR TITLE
Add pytest check for html tag structure

### DIFF
--- a/Page loisir.html
+++ b/Page loisir.html
@@ -81,3 +81,4 @@
               
 
               <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</html>

--- a/tests/test_html_structure.py
+++ b/tests/test_html_structure.py
@@ -1,0 +1,18 @@
+import os
+from bs4 import BeautifulSoup
+
+import pytest
+
+HTML_FILES = ["index.html", "Page loisir.html"]
+
+@pytest.mark.parametrize("filename", HTML_FILES)
+def test_single_html_tag(filename):
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), filename)
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    soup = BeautifulSoup(content, "html.parser")
+    html_tags = soup.find_all("html")
+    # Ensure there is exactly one html tag
+    assert len(html_tags) == 1, f"{filename} should contain exactly one <html> tag"
+    # Ensure closing tag exists after opening tag by checking string search
+    assert "</html>" in content.lower(), f"{filename} must contain a closing </html>"


### PR DESCRIPTION
## Summary
- add tests folder with pytest script to validate that `index.html` and `Page loisir.html` each have a single `<html>` tag and closing tag
- fix missing closing `</html>` tag in `Page loisir.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff60ea60483259347ee43931159be